### PR TITLE
feat: Notification library and notification endpoint

### DIFF
--- a/src/functions/notification.ts
+++ b/src/functions/notification.ts
@@ -1,0 +1,44 @@
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { forbiddenReply, introspect } from "..";
+import { Notification } from "../lib/Notification";
+import { NotificationMessage } from "../models/Notification";
+
+export async function notification(
+  request: HttpRequest,
+  context: InvocationContext
+): Promise<HttpResponseInit> {
+  const introspection = await introspect(request);
+  if (!introspection.isSystem) {
+    return forbiddenReply();
+  }
+
+  switch (request.method) {
+    case "POST": {
+      const body = (await request.json()) as NotificationMessage;
+
+      const result = await Notification.send(body);
+
+      if (result.isErr()) {
+        context.error(result.error);
+        return { status: 500 };
+      }
+
+      return { status: 204 };
+    }
+
+    default:
+      return { status: 405 };
+  }
+}
+
+app.http("notification", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  handler: notification,
+  route: "notification",
+});

--- a/src/lib/Notification.ts
+++ b/src/lib/Notification.ts
@@ -1,0 +1,39 @@
+import { Result, err, ok } from "neverthrow";
+import { NotificationMessage } from "../models/Notification";
+
+export class Notification {
+  static async send(message: NotificationMessage): Promise<Result<void, Error>> {
+    try {
+      const baseUrl = process.env.NTFY_BASE_URL;
+      if (!baseUrl) {
+        return err(new Error("Missing NTFY_BASE_URL environment variable"));
+      }
+
+      const url = new URL(message.topic, baseUrl);
+
+      const headers: Record<string, string> = {
+        "Content-Type": "text/plain",
+      };
+
+      if (message.actions.length > 0) {
+        headers["X-Actions"] = message.actions
+          .map((a) => `${a.action}, ${a.label}, ${a.url}`)
+          .join("; ");
+      }
+
+      const response = await fetch(url.toString(), {
+        method: "POST",
+        headers,
+        body: message.message,
+      });
+
+      if (!response.ok) {
+        return err(new Error(`Ntfy request failed with status ${response.status}`));
+      }
+
+      return ok(undefined);
+    } catch (error) {
+      return err(new Error("Failed to send notification", { cause: error }));
+    }
+  }
+}

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -1,0 +1,12 @@
+export interface NotificationAction {
+  action: string;
+  label: string;
+  url: string;
+}
+
+export interface NotificationMessage {
+  userId: string;
+  topic: string;
+  message: string;
+  actions: NotificationAction[];
+}


### PR DESCRIPTION
Adds a Notification library that posts push notifications to a Ntfy server, along with a system-only POST endpoint for triggering notifications.

Closes #13

Generated with [Claude Code](https://claude.ai/code)