### PR TITLE
fix: scheduled push notifications not sending (issue #18)

### DIFF
--- a/src/functions/notificationQueue.ts
+++ b/src/functions/notificationQueue.ts
@@ -14,7 +14,7 @@ async function notificationQueueHandler(
     !queueMessage.entityConfigId ||
     !queueMessage.suggestionEntityId
   ) {
-    context.error("Invalid notification queue message");
+    context.error("Invalid notification queue message", { queueMessage });
     return;
   }
 
@@ -23,7 +23,22 @@ async function notificationQueueHandler(
     entityConfigId: queueMessage.entityConfigId,
     suggestionEntityId: queueMessage.suggestionEntityId,
     textValues: queueMessage.textValues,
+    receivedAt: new Date().toISOString(),
   });
+
+  const entityExistsRes = await Entity.suggestionExists(queueMessage.suggestionEntityId);
+
+  if (entityExistsRes.isErr()) {
+    context.error("[notificationQueue] failed to check suggestion existence", entityExistsRes.error);
+    return;
+  }
+
+  if (!entityExistsRes.value) {
+    context.log("[notificationQueue] suggestion entity no longer exists — skipping notification", {
+      suggestionEntityId: queueMessage.suggestionEntityId,
+    });
+    return;
+  }
 
   const alreadyLoggedRes = await Entity.hasMatchingEntityLoggedInPastHour(
     queueMessage.userId,
@@ -37,13 +52,23 @@ async function notificationQueueHandler(
   }
 
   if (alreadyLoggedRes.value) {
-    context.log("[notificationQueue] user already logged a matching entity in the past hour — skipping notification");
+    context.log("[notificationQueue] user already logged a matching entity in the past hour — skipping notification", {
+      userId: queueMessage.userId,
+      entityConfigId: queueMessage.entityConfigId,
+      textValues: queueMessage.textValues,
+    });
     return;
   }
 
+  context.log("[notificationQueue] no recent matching entity found — proceeding to send notification");
+
   const addUrl = `${process.env.ORBIT_FE_BASE_URL}/entity/add?suggestion=${queueMessage.suggestionEntityId}`;
 
-  context.log("[notificationQueue] sending push notification", { addUrl });
+  context.log("[notificationQueue] sending push notification", {
+    addUrl,
+    userId: queueMessage.userId,
+    body: queueMessage.textValues.join("\n"),
+  });
 
   const sendRes = await Notification.send({
     userId: queueMessage.userId,
@@ -55,7 +80,7 @@ async function notificationQueueHandler(
   if (sendRes.isErr()) {
     context.error("[notificationQueue] Notification.send failed:", sendRes.error);
   } else {
-    context.log("[notificationQueue] Notification.send completed");
+    context.log("[notificationQueue] Notification.send completed successfully");
   }
 }
 

--- a/src/functions/suggestEntity.ts
+++ b/src/functions/suggestEntity.ts
@@ -84,6 +84,11 @@ export async function suggestEntity(
         return { status: 500 };
       }
 
+      context.log(
+        `[suggestEntity] enqueuing notification for entity ${entity.id}`,
+        { userId: payload.userId, entityConfigId: entity.type, textValues: textValuesRes.value }
+      );
+
       const enqueueRes = await NotificationQueue.enqueue({
         userId: payload.userId,
         entityConfigId: entity.type,

--- a/src/lib/Entity.ts
+++ b/src/lib/Entity.ts
@@ -1594,6 +1594,11 @@ export class Entity {
     textValues: string[]
   ): Promise<Result<boolean, Error>> {
     try {
+      if (textValues.length === 0) {
+        console.log("[Entity] hasMatchingEntityLoggedInPastHour: textValues is empty — skipping dedupe check");
+        return ok(false);
+      }
+
       const oneHourAgo = new Date(Date.now() - 3600000);
       const entities = await prisma.entity.findMany({
         where: {
@@ -1608,6 +1613,8 @@ export class Entity {
         },
       });
 
+      console.log(`[Entity] hasMatchingEntityLoggedInPastHour: found ${entities.length} non-suggestion entities of type ${entityConfigId} logged in past hour`, { textValues });
+
       for (const entity of entities) {
         const entityTextValues = [
           ...entity.shortTextProperties.map(p => p.propertyValue.value),
@@ -1615,6 +1622,7 @@ export class Entity {
         ];
 
         if (textValues.every(v => entityTextValues.includes(v))) {
+          console.log(`[Entity] hasMatchingEntityLoggedInPastHour: match found on entity ${entity.id}`, { entityTextValues, textValues });
           return ok(true);
         }
       }
@@ -1624,6 +1632,18 @@ export class Entity {
       return err(
         new Error("Failed to check for matching entity", { cause: error })
       );
+    }
+  }
+
+  static async suggestionExists(entityId: number): Promise<Result<boolean, Error>> {
+    try {
+      const entity = await prisma.entity.findUnique({
+        where: { id: entityId, suggestion: true },
+        select: { id: true },
+      });
+      return ok(entity !== null);
+    } catch (error) {
+      return err(new Error("Failed to check suggestion existence", { cause: error }));
     }
   }
 

--- a/src/lib/Notification.ts
+++ b/src/lib/Notification.ts
@@ -45,6 +45,10 @@ export class Notification {
       data: { actionUrls },
     });
 
+    let sent = 0;
+    let failed = 0;
+    let expired = 0;
+
     for (const sub of subscriptions) {
       try {
         console.log(`[Notification] sending to endpoint: ${sub.endpoint}`);
@@ -53,15 +57,24 @@ export class Notification {
           payload
         );
         console.log(`[Notification] sent successfully to ${sub.endpoint}`);
+        sent++;
       } catch (error: any) {
         if (error?.statusCode === 410) {
           console.log(`[Notification] subscription expired (410), deleting: ${sub.endpoint}`);
           await prisma.pushSubscription.delete({ where: { id: sub.id } });
+          expired++;
         } else {
-          console.error(`[Notification] failed to send to ${sub.endpoint}`, error);
+          console.error(`[Notification] failed to send to ${sub.endpoint}`, {
+            statusCode: error?.statusCode,
+            body: error?.body,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          failed++;
         }
       }
     }
+
+    console.log(`[Notification] send summary: sent=${sent} failed=${failed} expired=${expired} total=${subscriptions.length}`);
 
     return ok(undefined);
   }

--- a/src/lib/NotificationQueue.ts
+++ b/src/lib/NotificationQueue.ts
@@ -3,7 +3,7 @@ import { Result, err, ok } from "neverthrow";
 import { NotificationQueueMessage } from "../models/NotificationQueue";
 
 const QUEUE_NAME = "notification-queue";
-const NOTIFICATION_DELAY_SECONDS = 0;
+const NOTIFICATION_DELAY_SECONDS = 3600;
 
 function extractAccountName(connectionString: string): string {
   const match = /AccountName=([^;]+)/.exec(connectionString);


### PR DESCRIPTION
Fixes #18

- Change NOTIFICATION_DELAY_SECONDS from 0 to 3600 so notifications fire 1hr after suggestion creation instead of at midnight
- Fix vacuous-truth bug in hasMatchingEntityLoggedInPastHour where empty textValues incorrectly suppressed notifications
- Add Entity.suggestionExists() check before sending notification
- Add detailed logging throughout the notification pipeline to diagnose failures

Generated with [Claude Code](https://claude.ai/code)