### PR TITLE
feat: import medal configs and medals

### DIFF
--- a/src/functions/data.ts
+++ b/src/functions/data.ts
@@ -6,7 +6,7 @@ import {
 } from "@azure/functions";
 import { ENABLE_NUKE, forbiddenReply, introspect, jsonReply } from "..";
 import { Entity } from "../lib/Entity";
-
+import { Medal } from "../lib/Medal";
 import { Data } from "../lib/Data";
 import { ExportDataContents, NukedDataType } from "api-spec/models/Data";
 import { IntrospectionUser } from "api-spec/models/Introspection";
@@ -37,20 +37,32 @@ async function handleExport(
     endDate
   );
 
-  const res = await Entity.export(
-    userId,
-    body.entityConfigIds,
-    startDate,
-    endDate
-  );
+  const [entitiesRes, medalConfigsRes, medalsRes] = await Promise.all([
+    Entity.export(userId, body.entityConfigIds, startDate, endDate),
+    Medal.getConfigs(),
+    Medal.getMedals(userId),
+  ]);
 
-  if (res.isErr()) {
-    return {
-      status: 500,
-    };
+  if (entitiesRes.isErr()) {
+    return { status: 500 };
   }
 
-  return jsonReply({ entities: res.value, success: true });
+  if (medalConfigsRes.isErr()) {
+    context.error("Failed to export medal configs:", medalConfigsRes.error);
+    return { status: 500 };
+  }
+
+  if (medalsRes.isErr()) {
+    context.error("Failed to export medals:", medalsRes.error);
+    return { status: 500 };
+  }
+
+  return jsonReply({
+    entities: entitiesRes.value,
+    medalConfigs: medalConfigsRes.value,
+    medals: medalsRes.value,
+    success: true,
+  });
 }
 
 async function handleImport(

--- a/src/lib/Data.ts
+++ b/src/lib/Data.ts
@@ -14,6 +14,7 @@ import { Tagging } from "./Tagging";
 import { Entity } from "./Entity";
 import { ListConfig } from "./ListConfig";
 import { PropertyConfig } from "./PropertyConfig";
+import { Medal } from "./Medal";
 import {
   ListFilterTimeType,
   ListSortNativeProperty,
@@ -56,6 +57,7 @@ export class Data {
 
       const entityConfigMap: ImportEntityConfigMap = {};
       const entityPropertyConfigMap: ImportEntityPropertyConfigMap = {};
+      const medalConfigMap: Record<number, number> = {};
 
       const entityConfigsRes = await EntityConfig.getByUser(userId);
       const entityConfigHashMap: { hash: string; id: number }[] = [];
@@ -226,6 +228,93 @@ export class Data {
           listConfig.filter.includeTypes ?? []
         );
         await ListConfig.updateFilter(prismaListConfig.id, listConfig.filter);
+      }
+
+      if (data.medalConfigs) {
+        const existingMedalConfigsRes = await Medal.getConfigs();
+        if (existingMedalConfigsRes.isErr()) {
+          Logger.error(
+            "Failed to retrieve medal configs:",
+            existingMedalConfigsRes.error
+          );
+          return err(new Error("Failed to retrieve medal configs"));
+        }
+        const existingMedalConfigs = existingMedalConfigsRes.value;
+
+        for (const config of data.medalConfigs) {
+          const existingConfig = existingMedalConfigs.find((e) => {
+            return (
+              e.name === config.name &&
+              e.description === config.description &&
+              e.series === config.series &&
+              e.recurrence === config.recurrence &&
+              e.prestige === config.prestige &&
+              e.icon === config.icon &&
+              JSON.stringify(e.factRequests) ===
+                JSON.stringify(config.factRequests) &&
+              JSON.stringify(e.criteria) === JSON.stringify(config.criteria)
+            );
+          });
+
+          if (existingConfig) {
+            Logger.log("MedalConfig already exists, skipping:", config.name);
+            medalConfigMap[config.id] = existingConfig.id;
+            continue;
+          }
+
+          const createResult = await Medal.createConfig({
+            name: config.name,
+            description: config.description,
+            series: config.series,
+            recurrence: config.recurrence,
+            prestige: config.prestige,
+            icon: config.icon,
+            factRequests: config.factRequests,
+            criteria: config.criteria,
+          });
+
+          if (createResult.isErr()) {
+            Logger.error(
+              "Failed to create medal config:",
+              createResult.error
+            );
+            return err(new Error("Failed to create medal config"));
+          }
+
+          medalConfigMap[config.id] = createResult.value.id;
+        }
+      }
+
+      if (data.medals) {
+        for (const medal of data.medals) {
+          const newMedalConfigId = medalConfigMap[medal.medalConfigId];
+          if (newMedalConfigId === undefined) {
+            Logger.error(
+              `Medal references unknown medalConfigId: ${medal.medalConfigId}, skipping`
+            );
+            continue;
+          }
+
+          const existingMedal = await prisma.medal.findFirst({
+            where: {
+              userId,
+              medalConfigId: newMedalConfigId,
+              awardedAt: new Date(medal.awardedAt),
+            },
+          });
+
+          if (existingMedal) {
+            continue;
+          }
+
+          await prisma.medal.create({
+            data: {
+              userId,
+              medalConfigId: newMedalConfigId,
+              awardedAt: new Date(medal.awardedAt),
+            },
+          });
+        }
       }
 
       return ok(null);


### PR DESCRIPTION
Closes #32

Adds medal configs and medals to the import/export flow.

**Export**: `handleExport` now fetches medal configs and user medals in parallel and includes them in the response.

**Import**: `Data.import()` now handles `medalConfigs` and `medals` with content-based deduplication for configs and awardedAt-based deduplication for medals.

Generated with [Claude Code](https://claude.ai/code)