### PR TITLE
feat: chart updates (api-spec 1.103.0, Chart model, save/update endpoints)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@azure/storage-blob": "^12.28.0",
     "@azure/storage-queue": "^12.29.0",
     "@prisma/client": "^6.17.1",
-    "api-spec": "github:SikoSoft/api-spec#1.101.0",
+    "api-spec": "github:SikoSoft/api-spec#1.103.0",
     "argon2": "^0.41.1",
     "googleapis": "^171.4.0",
     "into-stream": "^9.0.0",

--- a/prisma/migrations/20260603093300_add_chart/migration.sql
+++ b/prisma/migrations/20260603093300_add_chart/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Chart" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "config" JSONB NOT NULL,
+    "userId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Chart_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_chart_userid" ON "Chart"("userId");
+
+-- CreateIndex (expression index for scanning version inside config)
+CREATE INDEX "idx_chart_version" ON "Chart" (((config->>'version')::int));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -897,3 +897,14 @@ model FactCache {
   @@unique([userId, contextKey])
   @@index([expiresAt])
 }
+
+model Chart {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(255)
+  config    Json
+  userId    String   @db.Uuid
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+}

--- a/src/functions/chart.ts
+++ b/src/functions/chart.ts
@@ -6,8 +6,20 @@ import {
 } from "@azure/functions";
 import { forbiddenReply, introspect, jsonReply } from "..";
 import { Chart } from "../lib/Chart";
-import { ChartRequestBody } from "../models/Chart";
+import { ChartRequestBody, ChartUpdateBody } from "../models/Chart";
 import { ChartRequest, DataWindow, DataWindowType } from "api-spec/models/Statistic";
+import { HttpMethod } from "../models/Endpoint";
+
+function buildDataWindow(body: ChartRequestBody): DataWindow {
+  if (body.dataWindow.type === DataWindowType.CUSTOM) {
+    return {
+      type: DataWindowType.CUSTOM,
+      start: new Date(body.dataWindow.start),
+      end: new Date(body.dataWindow.end),
+    };
+  }
+  return { type: body.dataWindow.type };
+}
 
 export async function chart(
   request: HttpRequest,
@@ -21,23 +33,12 @@ export async function chart(
   const userId = introspection.user.id;
 
   switch (request.method) {
-    case "POST": {
+    case HttpMethod.POST: {
       const body = (await request.json()) as ChartRequestBody;
-
-      let dataWindow: DataWindow;
-      if (body.dataWindow.type === DataWindowType.CUSTOM) {
-        dataWindow = {
-          type: DataWindowType.CUSTOM,
-          start: new Date(body.dataWindow.start),
-          end: new Date(body.dataWindow.end),
-        };
-      } else {
-        dataWindow = { type: body.dataWindow.type };
-      }
 
       const chartRequest: ChartRequest = {
         ...body,
-        dataWindow,
+        dataWindow: buildDataWindow(body),
       };
 
       const res = await Chart.getChartData(chartRequest, userId);
@@ -46,7 +47,38 @@ export async function chart(
         return { status: 500 };
       }
 
+      if (body.save && body.name) {
+        const { save: _save, name, dataWindow: _dw, ...config } = body;
+        const saveRes = await Chart.saveChart(userId, name, { ...config, dataWindow: body.dataWindow });
+        if (saveRes.isErr()) {
+          context.error(saveRes.error);
+          return { status: 500 };
+        }
+        return jsonReply({ segmentedData: res.value, chart: saveRes.value });
+      }
+
       return jsonReply({ segmentedData: res.value });
+    }
+
+    case HttpMethod.PUT: {
+      const idParam = request.params.id;
+      if (!idParam) {
+        return { status: 400 };
+      }
+      const id = parseInt(idParam, 10);
+      if (isNaN(id)) {
+        return { status: 400 };
+      }
+
+      const body = (await request.json()) as ChartUpdateBody;
+
+      const updateRes = await Chart.updateChart(userId, id, body.name, body.config);
+      if (updateRes.isErr()) {
+        context.error(updateRes.error);
+        return { status: 500 };
+      }
+
+      return jsonReply({ chart: updateRes.value });
     }
 
     default:
@@ -55,8 +87,8 @@ export async function chart(
 }
 
 app.http("chart", {
-  methods: ["POST"],
+  methods: ["POST", "PUT"],
   authLevel: "anonymous",
   handler: chart,
-  route: "chart",
+  route: "chart/{id?}",
 });

--- a/src/lib/Chart.ts
+++ b/src/lib/Chart.ts
@@ -19,6 +19,8 @@ import {
   ChartEntity,
   ChartEntityProperty,
   ChartSegment,
+  PrismaChart,
+  SavedChart,
 } from "../models/Chart";
 import { Assist } from "./Assist";
 import { EntityListQueryBuilder } from "./EntityListQueryBuilder";
@@ -374,6 +376,56 @@ export class Chart {
     d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
     const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
     return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  }
+
+  static async saveChart(
+    userId: string,
+    name: string,
+    config: object
+  ): Promise<Result<SavedChart, Error>> {
+    try {
+      const chart = await prisma.chart.create({
+        data: {
+          name,
+          config,
+          userId,
+        },
+      });
+      return ok(Chart.mapDataToSpec(chart));
+    } catch (error) {
+      return err(new Error("Failed to save chart", { cause: error }));
+    }
+  }
+
+  static async updateChart(
+    userId: string,
+    id: number,
+    name: string,
+    config: object
+  ): Promise<Result<SavedChart, Error>> {
+    try {
+      const chart = await prisma.chart.update({
+        where: { id, userId },
+        data: {
+          name,
+          config,
+        },
+      });
+      return ok(Chart.mapDataToSpec(chart));
+    } catch (error) {
+      return err(new Error("Failed to update chart", { cause: error }));
+    }
+  }
+
+  static mapDataToSpec(data: PrismaChart): SavedChart {
+    return {
+      id: data.id,
+      name: data.name,
+      config: data.config,
+      userId: data.userId,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+    };
   }
 
   private static applySegmentToContext(

--- a/src/models/Chart.ts
+++ b/src/models/Chart.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 import {
   ChartRequest,
   DataWindowType,
@@ -44,7 +45,26 @@ export type ChartRequestBodyDataWindow =
 
 export type ChartRequestBody = Omit<ChartRequest, "dataWindow"> & {
   dataWindow: ChartRequestBodyDataWindow;
+  save?: boolean;
+  name?: string;
 };
+
+export interface SavedChart {
+  id: number;
+  name: string;
+  config: Prisma.JsonValue;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const prismaChartValidator = Prisma.validator<Prisma.ChartDefaultArgs>()({});
+export type PrismaChart = Prisma.ChartGetPayload<typeof prismaChartValidator>;
+
+export interface ChartUpdateBody {
+  name: string;
+  config: object;
+}
 
 export interface ChartEntityProperty {
   propertyConfigId: number;


### PR DESCRIPTION
Implements chart updates from issue #37:

- Update api-spec to 1.103.0
- Add Prisma `Chart` model with JSON `config` field
- Add migration with expression index on `(config->>'version')::int` for fast version scanning
- Extend `ChartRequestBody` with optional `save` and `name` fields
- POST /chart: compute chart data; if `save: true` and `name` provided, persist chart and return `{ segmentedData, chart }`
- PUT /chart/{id}: update existing saved chart and return `{ chart }`

Closes #37

Generated with [Claude Code](https://claude.ai/code)