### PR TITLE
feat: add GET and DELETE support to /chart endpoint

### DIFF
--- a/src/functions/chart.ts
+++ b/src/functions/chart.ts
@@ -33,6 +33,32 @@ export async function chart(
   const userId = introspection.user.id;
 
   switch (request.method) {
+    case HttpMethod.GET: {
+      const idParam = request.params.id;
+      if (idParam) {
+        const id = parseInt(idParam, 10);
+        if (isNaN(id)) {
+          return { status: 400 };
+        }
+        const res = await Chart.getChart(userId, id);
+        if (res.isErr()) {
+          context.error(res.error);
+          return { status: 500 };
+        }
+        if (!res.value) {
+          return { status: 404 };
+        }
+        return jsonReply({ ...res.value });
+      } else {
+        const res = await Chart.getCharts(userId);
+        if (res.isErr()) {
+          context.error(res.error);
+          return { status: 500 };
+        }
+        return jsonReply({ charts: res.value });
+      }
+    }
+
     case HttpMethod.POST: {
       const body = (await request.json()) as ChartRequestBody;
 
@@ -84,13 +110,30 @@ export async function chart(
       return jsonReply({ chart: updateRes.value });
     }
 
+    case HttpMethod.DELETE: {
+      const idParam = request.params.id;
+      if (!idParam) {
+        return { status: 400 };
+      }
+      const id = parseInt(idParam, 10);
+      if (isNaN(id)) {
+        return { status: 400 };
+      }
+      const res = await Chart.deleteChart(userId, id);
+      if (res.isErr()) {
+        context.error(res.error);
+        return { status: 500 };
+      }
+      return { status: 204 };
+    }
+
     default:
       return { status: 405 };
   }
 }
 
 app.http("chart", {
-  methods: ["POST", "PUT"],
+  methods: ["GET", "POST", "PUT", "DELETE"],
   authLevel: "anonymous",
   handler: chart,
   route: "chart/{id?}",

--- a/src/lib/Chart.ts
+++ b/src/lib/Chart.ts
@@ -378,6 +378,39 @@ export class Chart {
     return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
   }
 
+  static async getCharts(userId: string): Promise<Result<SavedChart[], Error>> {
+    try {
+      const charts = await prisma.chart.findMany({
+        where: { userId },
+      });
+      return ok(charts.map(Chart.mapDataToSpec));
+    } catch (error) {
+      return err(new Error("Failed to get charts", { cause: error }));
+    }
+  }
+
+  static async getChart(userId: string, id: number): Promise<Result<SavedChart | null, Error>> {
+    try {
+      const chart = await prisma.chart.findFirst({
+        where: { id, userId },
+      });
+      return ok(chart ? Chart.mapDataToSpec(chart) : null);
+    } catch (error) {
+      return err(new Error("Failed to get chart", { cause: error }));
+    }
+  }
+
+  static async deleteChart(userId: string, id: number): Promise<Result<void, Error>> {
+    try {
+      await prisma.chart.delete({
+        where: { id, userId },
+      });
+      return ok(undefined);
+    } catch (error) {
+      return err(new Error("Failed to delete chart", { cause: error }));
+    }
+  }
+
   static async saveChart(
     userId: string,
     name: string,


### PR DESCRIPTION
Add GET and DELETE methods to the /chart endpoint.

- `GET /chart` returns an array of the user's saved charts as `{ charts: [...] }`
- `GET /chart/{id}` returns a single chart with fields spread on the top-level response (404 if not found)
- `DELETE /chart/{id}` removes the chart and returns 204

Closes #39

Generated with [Claude Code](https://claude.ai/code)