### PR TITLE
feat: include criteriaProgress in medalConfig GET responses

### DIFF
--- a/src/__tests__/Medal.test.ts
+++ b/src/__tests__/Medal.test.ts
@@ -325,6 +325,80 @@ describe('Medal', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // getConfigWithProgress
+  // ---------------------------------------------------------------------------
+
+  describe('getConfigWithProgress', () => {
+    it('returns err when the config is not found', async () => {
+      vi.mocked(prisma.medalConfig.findUnique).mockResolvedValue(null as any);
+
+      const result = await Medal.getConfigWithProgress(99, 'user1');
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('not found');
+    });
+
+    it('includes resolved fact values in criteriaProgress', async () => {
+      const now = new Date();
+      vi.mocked(prisma.medalConfig.findUnique).mockResolvedValue(
+        makePrismaConfig({ createdAt: now, updatedAt: now }) as any
+      );
+      vi.mocked(Fact.resolve).mockResolvedValue(42);
+
+      const result = await Medal.getConfigWithProgress(1, 'user1');
+
+      expect(result.isOk()).toBe(true);
+      const config = result._unsafeUnwrap();
+      expect(config.criteriaProgress).toEqual([{ alias: 'count', value: 42 }]);
+    });
+
+    it('omits entries for facts that could not be resolved', async () => {
+      const now = new Date();
+      vi.mocked(prisma.medalConfig.findUnique).mockResolvedValue(
+        makePrismaConfig({ createdAt: now, updatedAt: now }) as any
+      );
+      vi.mocked(Fact.resolve).mockResolvedValue(undefined);
+
+      const result = await Medal.getConfigWithProgress(1, 'user1');
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().criteriaProgress).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getConfigsWithProgress
+  // ---------------------------------------------------------------------------
+
+  describe('getConfigsWithProgress', () => {
+    it('returns an empty array when there are no configs', async () => {
+      vi.mocked(prisma.medalConfig.findMany).mockResolvedValue([]);
+
+      const result = await Medal.getConfigsWithProgress('user1');
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toEqual([]);
+    });
+
+    it('resolves criteriaProgress for each config', async () => {
+      const now = new Date();
+      vi.mocked(prisma.medalConfig.findMany).mockResolvedValue([
+        makePrismaConfig({ id: 1, createdAt: now, updatedAt: now }),
+        makePrismaConfig({ id: 2, createdAt: now, updatedAt: now }),
+      ] as any);
+      vi.mocked(Fact.resolve).mockResolvedValue(7);
+
+      const result = await Medal.getConfigsWithProgress('user1');
+
+      expect(result.isOk()).toBe(true);
+      const configs = result._unsafeUnwrap();
+      expect(configs).toHaveLength(2);
+      expect(configs[0].criteriaProgress).toEqual([{ alias: 'count', value: 7 }]);
+      expect(configs[1].criteriaProgress).toEqual([{ alias: 'count', value: 7 }]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // checkForDisbursement
   // ---------------------------------------------------------------------------
 

--- a/src/functions/medalConfig.ts
+++ b/src/functions/medalConfig.ts
@@ -17,19 +17,20 @@ export async function medalConfig(
     return forbiddenReply();
   }
 
+  const userId = introspection.user.id;
   const id = request.params.id ? parseInt(request.params.id, 10) : undefined;
 
   switch (request.method) {
     case "GET": {
       if (id !== undefined) {
-        const res = await Medal.getConfig(id);
+        const res = await Medal.getConfigWithProgress(id, userId);
         if (res.isErr()) {
           context.error(res.error);
           return { status: 500 };
         }
         return jsonReply({ ...res.value });
       }
-      const res = await Medal.getConfigs();
+      const res = await Medal.getConfigsWithProgress(userId);
       if (res.isErr()) {
         context.error(res.error);
         return { status: 500 };

--- a/src/lib/Medal.ts
+++ b/src/lib/Medal.ts
@@ -5,8 +5,10 @@ import { Medal as MedalSpec } from "api-spec/models";
 import { Criteria, Criterion, FactRequest } from "api-spec/models/Medal";
 import { HookContext } from "../models/Hook";
 import {
+  CriteriaProgress,
   MedalConfigCreateBody,
   MedalConfigUpdateBody,
+  MedalConfigWithProgress,
   PrismaMedal,
   PrismaMedalConfig,
 } from "../models/Medal";
@@ -146,6 +148,49 @@ export class Medal {
     }
   }
 
+  static async getConfigWithProgress(
+    id: number,
+    userId: string
+  ): Promise<Result<MedalConfigWithProgress, Error>> {
+    try {
+      const config = await prisma.medalConfig.findUnique({ where: { id } });
+      if (!config) {
+        return err(new Error("Medal config not found"));
+      }
+      const base = Medal.mapConfigToSpec(config);
+      const criteriaProgress = await Medal.resolveCriteriaProgress(
+        base.factRequests,
+        userId
+      );
+      return ok({ ...base, criteriaProgress });
+    } catch (error) {
+      return err(new Error("Failed to fetch medal config", { cause: error }));
+    }
+  }
+
+  static async getConfigsWithProgress(
+    userId: string
+  ): Promise<Result<MedalConfigWithProgress[], Error>> {
+    try {
+      const configs = await prisma.medalConfig.findMany({
+        orderBy: { prestige: "desc" },
+      });
+      const results = await Promise.all(
+        configs.map(async (config) => {
+          const base = Medal.mapConfigToSpec(config);
+          const criteriaProgress = await Medal.resolveCriteriaProgress(
+            base.factRequests,
+            userId
+          );
+          return { ...base, criteriaProgress };
+        })
+      );
+      return ok(results);
+    } catch (error) {
+      return err(new Error("Failed to fetch medal configs", { cause: error }));
+    }
+  }
+
   static async getMedals(
     userId: string
   ): Promise<Result<MedalSpec.Medal[], Error>> {
@@ -255,6 +300,20 @@ export class Medal {
         }
       }
     }
+  }
+
+  private static async resolveCriteriaProgress(
+    factRequests: MedalSpec.FactRequest[],
+    userId: string
+  ): Promise<CriteriaProgress[]> {
+    const progress: CriteriaProgress[] = [];
+    for (const factRequest of factRequests) {
+      const value = await Fact.resolve(factRequest.context, userId);
+      if (value !== undefined) {
+        progress.push({ alias: factRequest.alias, value });
+      }
+    }
+    return progress;
   }
 
   private static collectCriteriaAliases(

--- a/src/models/Medal.ts
+++ b/src/models/Medal.ts
@@ -2,6 +2,15 @@ import { z } from "zod";
 import { Prisma } from "@prisma/client";
 import { Medal as MedalSpec } from "api-spec/models";
 
+export interface CriteriaProgress {
+  alias: string;
+  value: string | number | boolean;
+}
+
+export interface MedalConfigWithProgress extends MedalSpec.MedalConfig {
+  criteriaProgress: CriteriaProgress[];
+}
+
 const CriterionSchema = z.object({
   fact: z.string(),
   operator: z.enum(["==", "!=", ">", ">=", "<", "<=", "contains"]),


### PR DESCRIPTION
For each config returned by GET /medalConfig and GET /medalConfig/:id, resolve each factRequest via Fact.resolve and include the results as a criteriaProgress array ({ alias, value }) so clients can display per-medal unlock progress.

Resolves #41

Generated with [Claude Code](https://claude.ai/code)