### PR TITLE
fix: save identified flag in list filter update

### DIFF
--- a/src/lib/ListConfig.ts
+++ b/src/lib/ListConfig.ts
@@ -513,6 +513,8 @@ export class ListConfig {
             typeof filter.published === "undefined" ? null : filter.published,
           suggested:
             typeof filter.suggested === "undefined" ? null : filter.suggested,
+          identified:
+            typeof filter.identified === "undefined" ? null : filter.identified,
         },
       });
       return ok(null);


### PR DESCRIPTION
Treat the `identified` flag the same as `published` and `suggested` in `ListConfig.updateFilter`, persisting `null` as a valid value when the flag is undefined.

Closes #42

Generated with [Claude Code](https://claude.ai/code)