### PR TITLE
fix: use api-spec defaultListFilter for filter flags when creating list config

### DIFF
--- a/src/lib/ListConfig.ts
+++ b/src/lib/ListConfig.ts
@@ -37,9 +37,21 @@ export class ListConfig {
           //public: false,
           filter: {
             create: {
-              includeAll: true,
-              includeUntagged: true,
-              includeAllTagging: true,
+              includeAll: defaultListFilter.includeAll ?? true,
+              includeUntagged: defaultListFilter.includeUntagged ?? true,
+              includeAllTagging: defaultListFilter.includeAllTagging ?? true,
+              published:
+                typeof defaultListFilter.published === "undefined"
+                  ? null
+                  : defaultListFilter.published,
+              suggested:
+                typeof defaultListFilter.suggested === "undefined"
+                  ? null
+                  : defaultListFilter.suggested,
+              identified:
+                typeof defaultListFilter.identified === "undefined"
+                  ? null
+                  : defaultListFilter.identified,
               time: { create: { type: ListFilterTimeType.ALL_TIME } },
             },
           },


### PR DESCRIPTION
When creating a new list-config, the published, suggested, and identified flags were not being set from api-spec defaults.

This fix reads all relevant filter flags from `defaultListFilter` in api-spec using the same null-coalescing logic as the update handler (undefined → null to mean "use both true and false").

Closes #45

Generated with [Claude Code](https://claude.ai/code)