### PR TITLE
feat: auto-extend session lifespan on introspect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,20 @@ export const introspect = async (
     const session = sessionRes.value;
 
     if (session) {
+      const now = new Date();
+      const timeRemaining = session.expiresAt.getTime() - now.getTime();
+      let effectiveExpiresAt = session.expiresAt;
+
+      if (timeRemaining < IdentityManager.SESSION_EXTENSION_THRESHOLD_MS) {
+        const extendRes = await IdentityManager.extendSession(
+          authToken,
+          session.createdAt
+        );
+        if (!extendRes.isErr()) {
+          effectiveExpiresAt = extendRes.value;
+        }
+      }
+
       return {
         isLoggedIn: true,
         isSystem: false,
@@ -92,7 +106,7 @@ export const introspect = async (
           ? { googleLink: true, googleAccount: session.user.googleAccount[0] }
           : { googleLink: false }),
         sessionId: authToken,
-        expiresAt: session.expiresAt,
+        expiresAt: effectiveExpiresAt,
       };
     }
   }

--- a/src/lib/IdentityManager.ts
+++ b/src/lib/IdentityManager.ts
@@ -25,6 +25,9 @@ export class IdentityManager {
   static readonly ALGORITHM = "aes-256-gcm";
   static IV_LENGTH = 12;
   static KEY = IdentityManager.getValidatedEncryptionKey();
+  static readonly SESSION_EXTENSION_THRESHOLD_MS = 60 * 60 * 1000;
+  static readonly SESSION_EXTENSION_DAYS = 1;
+  static readonly SESSION_MAX_LIFESPAN_DAYS = 7;
 
   private static getValidatedEncryptionKey(): Buffer {
     const encryptionKey = process.env.ENCRYPTION_KEY;
@@ -190,6 +193,36 @@ export class IdentityManager {
       return ok(result);
     } catch (error) {
       return err(error);
+    }
+  }
+
+  static async extendSession(
+    authToken: string,
+    createdAt: Date
+  ): Promise<Result<Date, Error>> {
+    try {
+      const now = new Date();
+      const maxExpiresAt = new Date(createdAt);
+      maxExpiresAt.setDate(
+        maxExpiresAt.getDate() + IdentityManager.SESSION_MAX_LIFESPAN_DAYS
+      );
+
+      const extendedExpiresAt = new Date(now);
+      extendedExpiresAt.setDate(
+        extendedExpiresAt.getDate() + IdentityManager.SESSION_EXTENSION_DAYS
+      );
+
+      const newExpiresAt =
+        extendedExpiresAt < maxExpiresAt ? extendedExpiresAt : maxExpiresAt;
+
+      await prisma.session.update({
+        where: { authToken },
+        data: { expiresAt: newExpiresAt },
+      });
+
+      return ok(newExpiresAt);
+    } catch (error) {
+      return err(new Error("Failed to extend session", { cause: error }));
     }
   }
 


### PR DESCRIPTION
When less than one hour remains on a session token's validity, the introspect handler now extends the expiration by one day. A maximum lifespan of 7 days from the session's creation time is enforced so the expiration can never be pushed past that ceiling.

Closes #47

Generated with [Claude Code](https://claude.ai/code)