### PR TITLE
feat: add propertySum fact type support

### DIFF
--- a/docs/fact-system.md
+++ b/docs/fact-system.md
@@ -15,6 +15,7 @@ Each `FactContext` has an `operation` field that determines the computation path
 | `entityCount` | Number of entities matching a list filter | `filter: ListFilter` |
 | `uniqueTagCount` | Count of distinct tag labels across filtered entities | `filter: ListFilter` |
 | `medalCount` | Number of times a specific medal config (or series) has been earned | `medalConfigId`, `series`, optional `start`/`end` |
+| `propertySum` | Sum of all integer property values for the given property across filtered entities | `propertyConfigId: number`, `filter: ListFilter` |
 | `analysisClassification` | A numeric value produced by an external AI analysis service | `filter: ListFilter`, `analysisType: AnalysisClassificationType` |
 
 Available `analysisType` values: `"morningFasting"`, `"afternoonSnacking"`, `"caffeineIntake"`.
@@ -42,6 +43,7 @@ TTLs by operation (defined in `src/models/FactCache.ts`):
 | `entityCount` | 1 hour |
 | `uniqueTagCount` | 1 hour |
 | `medalCount` | 1 hour |
+| `propertySum` | 1 hour |
 | `analysisClassification` | 24 hours |
 
 Cache errors (DB failures on read or write) are treated as misses — the system always falls back to a fresh computation rather than throwing.

--- a/docs/medal-system.md
+++ b/docs/medal-system.md
@@ -48,6 +48,21 @@ A `FactRequest` binds a `FactContext` to an **alias** string. The alias is used 
 
 The Fact system resolves this via `Fact.resolve(context, userId)` and stores the result as `facts["fastingDays"] = <computed value>`. See [fact-system.md](./fact-system.md) for the full list of operations and caching behaviour.
 
+A `propertySum` fact request looks like:
+
+```json
+{
+  "alias": "totalCalories",
+  "context": {
+    "operation": "propertySum",
+    "propertyConfigId": 7,
+    "filter": { "includeTypes": [3] }
+  }
+}
+```
+
+This sums all integer values of the property with `propertyConfigId: 7` across entities matching the filter. If an entity has the property set multiple times (repeatable property), each value is included in the sum.
+
 ---
 
 ## StreakRequests
@@ -74,9 +89,11 @@ A `StreakRequest` measures **consecutive time periods** where a condition held. 
 
 Segment boundaries are computed in the **user's local timezone** (read from the `TIMEZONE` setting, stored as UTC offset minutes). For example, a `DAY` segment at UTC+5:30 runs from 00:00 to 23:59 Indian Standard Time, not UTC midnight.
 
-### Non-classification streaks (entityCount, uniqueTagCount, medalCount)
+### Non-classification streaks (entityCount, uniqueTagCount, medalCount, propertySum)
 
 For these operations the streak engine calls `Fact.resolve` with the date range for each segment injected into the `innerContext.filter`. The result is a regular cached fact lookup scoped to that time window.
+
+`propertySum` computes the sum of all integer property values (identified by `propertyConfigId`) across entities that match the filter within the segment's time window. If no matching entities have the property, the segment value is 0.
 
 ### analysisClassification streaks
 
@@ -158,7 +175,7 @@ The transaction isolation prevents race conditions where two concurrent requests
 
 ### What triggers a disbursement check
 
-**Entity-based medals** (`entityCount`, `uniqueTagCount`, `medalCount` criteria): `Entity.ts` calls `Hook.trigger` on every entity create, update, and delete. `processHook` dequeues these asynchronously and runs `checkForDisbursement`.
+**Entity-based medals** (`entityCount`, `uniqueTagCount`, `medalCount`, `propertySum` criteria): `Entity.ts` calls `Hook.trigger` on every entity create, update, and delete. `processHook` dequeues these asynchronously and runs `checkForDisbursement`.
 
 **Analysis-classification streak medals**: entity mutations are the wrong trigger because the AI data for the current segment won't exist yet at mutation time. Two triggers cover this instead:
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@azure/storage-blob": "^12.28.0",
     "@azure/storage-queue": "^12.29.0",
     "@prisma/client": "^6.17.1",
-    "api-spec": "github:SikoSoft/api-spec#1.111.0",
+    "api-spec": "github:SikoSoft/api-spec#1.112.0",
     "argon2": "^0.41.1",
     "googleapis": "^171.4.0",
     "into-stream": "^9.0.0",

--- a/src/lib/Fact.ts
+++ b/src/lib/Fact.ts
@@ -197,6 +197,7 @@ export class Fact {
    * - ENTITY_COUNT: filtered count via EntityListQueryBuilder
    * - UNIQUE_TAG_COUNT: distinct tag labels across filtered entities
    * - MEDAL_COUNT: awarded medal count with optional date range
+   * - PROPERTY_SUM: sum of all IntPropertyValues for the given propertyConfigId across filtered entities
    * - ANALYSIS_CLASSIFICATION: always returns undefined — this operation's values come from an
    *   external AI pipeline and must be pre-seeded into FactCache via `writeCache` (Chart engine
    *   path) or queried from `analysisClassificationResult` directly (streak path). The `filter`
@@ -249,6 +250,29 @@ export class Fact {
         });
         Logger.log(`[Fact] compute MEDAL_COUNT userId=${userId} medalConfigId=${context.medalConfigId} series=${context.series} result=${count}`);
         return count;
+      }
+      case FactOperation.PROPERTY_SUM: {
+        const builder = new EntityListQueryBuilder();
+        builder.setUserId(userId);
+        builder.setFilter(context.filter);
+        const entityIds = await builder.runIdsQuery();
+        Logger.log(`[Fact] compute PROPERTY_SUM userId=${userId} propertyConfigId=${context.propertyConfigId} entityIds.length=${entityIds.length}`);
+        if (entityIds.length === 0) {
+          Logger.log(`[Fact] compute PROPERTY_SUM userId=${userId} propertyConfigId=${context.propertyConfigId} result=0 (no entities)`);
+          return 0;
+        }
+        const agg = await prisma.intPropertyValue.aggregate({
+          _sum: { value: true },
+          where: {
+            entityPropertyValue: {
+              entityId: { in: entityIds },
+              propertyConfigId: context.propertyConfigId,
+            },
+          },
+        });
+        const sum = agg._sum.value ?? 0;
+        Logger.log(`[Fact] compute PROPERTY_SUM userId=${userId} propertyConfigId=${context.propertyConfigId} result=${sum}`);
+        return sum;
       }
       case FactOperation.ANALYSIS_CLASSIFICATION:
         Logger.log(`[Fact] compute ANALYSIS_CLASSIFICATION userId=${userId} — skipped (handled externally)`);

--- a/src/lib/Streak.ts
+++ b/src/lib/Streak.ts
@@ -269,6 +269,8 @@ export class Streak {
    * Returns a copy of `ctx` with a time range filter injected so the fact is scoped
    * to a single streak segment. Returns null for operations that cannot accept a date
    * range (e.g. ANALYSIS_CLASSIFICATION, which is handled via a direct DB query instead).
+   * ENTITY_COUNT, UNIQUE_TAG_COUNT, and PROPERTY_SUM inject the range into filter.time.
+   * MEDAL_COUNT injects into top-level start/end fields.
    */
   private static injectDateRange(
     ctx: FactContext,
@@ -281,6 +283,7 @@ export class Streak {
     switch (ctx.operation) {
       case FactOperation.ENTITY_COUNT:
       case FactOperation.UNIQUE_TAG_COUNT:
+      case FactOperation.PROPERTY_SUM:
         return {
           ...ctx,
           filter: {

--- a/src/models/FactCache.ts
+++ b/src/models/FactCache.ts
@@ -10,6 +10,7 @@ export const FACT_TTL_MS: Record<FactOperation, number> = {
   [FactOperation.UNIQUE_TAG_COUNT]: 60 * 60 * 1000,
   [FactOperation.MEDAL_COUNT]: 60 * 60 * 1000,
   [FactOperation.ANALYSIS_CLASSIFICATION]: 24 * 60 * 60 * 1000,
+  [FactOperation.PROPERTY_SUM]: 60 * 60 * 1000,
 };
 
 const prismaFactCacheValidator =


### PR DESCRIPTION
Closes #51

Adds support for the new `propertySum` fact type introduced in api-spec 1.112.0.

## Changes

- `package.json` — api-spec bumped to `1.112.0`
- `src/models/FactCache.ts` — `PROPERTY_SUM` added to `FACT_TTL_MS` (1 hour)
- `src/lib/Fact.ts` — `PROPERTY_SUM` compute path: fetches filtered entity IDs then aggregates `IntPropertyValue.value` for the given `propertyConfigId`
- `src/lib/Streak.ts` — `PROPERTY_SUM` added to `injectDateRange` filter-time branch (same as entityCount/uniqueTagCount)
- `docs/fact-system.md` — operations table and TTL table updated
- `docs/medal-system.md` — streak section, disbursement triggers, and example factRequest updated

Generated with [Claude Code](https://claude.ai/code)