### PR TITLE
fix: replace deprecated 'suggestion' field with 'suggested' in EntitySuggestion

### DIFF
--- a/src/lib/EntitySuggestion.ts
+++ b/src/lib/EntitySuggestion.ts
@@ -107,7 +107,7 @@ export class EntitySuggestion {
         where: {
           userId,
           entityConfigId,
-          suggestion: false,
+          suggested: false,
           createdAt: { gte: oneHourAgo },
         },
         include: {


### PR DESCRIPTION
Fixes #53

In `src/lib/EntitySuggestion.ts:110`, inside `hasMatchingEntityLoggedInPastHour`, the Prisma `where` clause used the deprecated field name `suggestion: false`. Updated to `suggested: false` to match the current schema.

Generated with [Claude Code](https://claude.ai/code)