### PR TITLE
Add WorkspaceChart model and PUT workspace charts support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@azure/storage-blob": "^12.28.0",
     "@azure/storage-queue": "^12.29.0",
     "@prisma/client": "^6.17.1",
-    "api-spec": "github:SikoSoft/api-spec#1.119.0",
+    "api-spec": "github:SikoSoft/api-spec#1.120.0",
     "argon2": "^0.41.1",
     "googleapis": "^171.4.0",
     "into-stream": "^9.0.0",

--- a/prisma/migrations/20260617080000_add_workspace_charts/migration.sql
+++ b/prisma/migrations/20260617080000_add_workspace_charts/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "WorkspaceChart" (
+    "id" SERIAL NOT NULL,
+    "workspaceId" UUID NOT NULL,
+    "chartId" INTEGER NOT NULL,
+    "userId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkspaceChart_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkspaceChart_workspaceId_chartId_key" ON "WorkspaceChart"("workspaceId", "chartId");
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceChart" ADD CONSTRAINT "WorkspaceChart_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -714,6 +714,7 @@ model Workspace {
   workspaceListConfigs WorkspaceListConfig[]
   workspaceStreaks      WorkspaceStreak[]
   workspaceFacts       WorkspaceFact[]
+  workspaceCharts      WorkspaceChart[]
 }
 
 model WorkspaceListConfig {
@@ -747,6 +748,18 @@ model WorkspaceFact {
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
   @@unique([workspaceId, factId])
+}
+
+model WorkspaceChart {
+  id          Int       @id @default(autoincrement())
+  workspaceId String    @db.Uuid
+  chartId     Int
+  userId      String    @db.Uuid
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, chartId])
 }
 
 model AccessPolicy {

--- a/src/lib/Workspace.ts
+++ b/src/lib/Workspace.ts
@@ -31,6 +31,7 @@ export class Workspace {
           workspaceListConfigs: true,
           workspaceStreaks: true,
           workspaceFacts: true,
+          workspaceCharts: true,
         },
       });
 
@@ -55,6 +56,9 @@ export class Workspace {
       if (body.facts !== undefined) {
         await prisma.workspaceFact.deleteMany({ where: { workspaceId: id } });
       }
+      if (body.charts !== undefined) {
+        await prisma.workspaceChart.deleteMany({ where: { workspaceId: id } });
+      }
 
       const updated = await prisma.workspace.update({
         where: { id, userId },
@@ -78,11 +82,17 @@ export class Workspace {
               create: body.facts.map(factId => ({ factId, userId })),
             },
           }),
+          ...(body.charts !== undefined && {
+            workspaceCharts: {
+              create: body.charts.map(chartId => ({ chartId, userId })),
+            },
+          }),
         },
         include: {
           workspaceListConfigs: true,
           workspaceStreaks: true,
           workspaceFacts: true,
+          workspaceCharts: true,
         },
       });
 
@@ -115,6 +125,7 @@ export class Workspace {
           workspaceListConfigs: true,
           workspaceStreaks: true,
           workspaceFacts: true,
+          workspaceCharts: true,
         },
       });
 
@@ -134,6 +145,7 @@ export class Workspace {
           workspaceListConfigs: true,
           workspaceStreaks: true,
           workspaceFacts: true,
+          workspaceCharts: true,
         },
         orderBy: { name: "asc" },
       });
@@ -157,6 +169,7 @@ export class Workspace {
       listConfigs: data.workspaceListConfigs.map(wlc => wlc.listConfigId),
       streaks: data.workspaceStreaks.map(ws => ws.streakId),
       facts: data.workspaceFacts.map(wf => wf.factId),
+      charts: data.workspaceCharts.map(wc => wc.chartId),
     };
   }
 }

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -18,6 +18,7 @@ export const WorkspaceUpdateBodySchema = z.object({
   listConfigs: z.array(z.string()).optional(),
   streaks: z.array(z.number().int()).optional(),
   facts: z.array(z.number().int()).optional(),
+  charts: z.array(z.number().int()).optional(),
 });
 export type WorkspaceUpdateBody = z.infer<typeof WorkspaceUpdateBodySchema>;
 
@@ -26,6 +27,7 @@ const prismaWorkspaceValidator = Prisma.validator<Prisma.WorkspaceFindManyArgs>(
     workspaceListConfigs: true,
     workspaceStreaks: true,
     workspaceFacts: true,
+    workspaceCharts: true,
   },
 });
 


### PR DESCRIPTION
## Summary
- Bump api-spec to 1.120.0
- Add WorkspaceChart Prisma model (mirrors WorkspaceStreak/WorkspaceFact)
- Update PUT workspace endpoint to accept optional charts array of numbers
- Map WorkspaceChart records to charts in returned workspace data

Closes #59

⚠️ Includes a Prisma schema change + hand-authored migration (no DB/network access in the sandbox to run `prisma migrate dev`). Please verify the migration and run `npm install` + `npx prisma generate` before merging.

Generated with [Claude Code](https://claude.ai/code)