### PR TITLE
Add comments feature with likes/dislikes and allowComments toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@azure/storage-blob": "^12.28.0",
     "@azure/storage-queue": "^12.29.0",
     "@prisma/client": "^6.17.1",
-    "api-spec": "github:SikoSoft/api-spec#1.122.0",
+    "api-spec": "github:SikoSoft/api-spec#1.123.0",
     "argon2": "^0.41.1",
     "googleapis": "^171.4.0",
     "into-stream": "^9.0.0",

--- a/prisma/migrations/20260623090000_add_comments/migration.sql
+++ b/prisma/migrations/20260623090000_add_comments/migration.sql
@@ -1,0 +1,49 @@
+-- AlterTable
+ALTER TABLE "Entity" ADD COLUMN     "allowComments" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "EntityConfig" ADD COLUMN     "allowComments" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "Comment" (
+    "id" SERIAL NOT NULL,
+    "entityId" INTEGER NOT NULL,
+    "userId" UUID,
+    "guestName" VARCHAR(128),
+    "body" TEXT NOT NULL,
+    "published" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Comment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CommentReaction" (
+    "id" SERIAL NOT NULL,
+    "commentId" INTEGER NOT NULL,
+    "userId" UUID,
+    "ip" VARCHAR(64),
+    "type" VARCHAR(16) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CommentReaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_comment_entityid_createdat" ON "Comment"("entityId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CommentReaction_commentId_userId_key" ON "CommentReaction"("commentId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CommentReaction_commentId_ip_key" ON "CommentReaction"("commentId", "ip");
+
+-- CreateIndex
+CREATE INDEX "idx_commentreaction_commentid" ON "CommentReaction"("commentId");
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommentReaction" ADD CONSTRAINT "CommentReaction_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "Comment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -243,6 +243,7 @@ model Entity {
   suggested             Boolean                     @default(false)
   published             Boolean                     @default(false)
   identified            Boolean                     @default(false)
+  allowComments         Boolean                     @default(false)
   tags                  EntityTag[]
   booleanProperties     EntityBooleanProperty[]
   dateProperties        EntityDateProperty[]
@@ -251,6 +252,7 @@ model Entity {
   longTextProperties    EntityLongTextProperty[]
   shortTextProperties   EntityShortTextProperty[]
   calculatedProperties  EntityCalculatedProperty[]
+  comments              Comment[]
 
   entityConfig EntityConfig        @relation(fields: [entityConfigId], references: [id], onDelete: Cascade)
   accessPolicy EntityAccessPolicy?
@@ -352,6 +354,7 @@ model EntityConfig {
   aiIdentifyPrompt      String?          @db.VarChar(255)
   public                Boolean          @default(false)
   allowTags             Boolean          @default(false)
+  allowComments         Boolean          @default(false)
 
   entityPropertyConfigOrders EntityPropertyConfigOrder[]
   entities                   Entity[]
@@ -413,6 +416,37 @@ model Leaderboard {
   duration Int      @default(0)
   time     DateTime @updatedAt
   ip       String   @db.VarChar(64)
+}
+
+model Comment {
+  id        Int      @id @default(autoincrement())
+  entityId  Int
+  userId    String?  @db.Uuid
+  guestName String?  @db.VarChar(128)
+  body      String
+  published Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  entity    Entity            @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  reactions CommentReaction[]
+
+  @@index([entityId, createdAt], map: "idx_comment_entityid_createdat")
+}
+
+model CommentReaction {
+  id        Int      @id @default(autoincrement())
+  commentId Int
+  userId    String?  @db.Uuid
+  ip        String?  @db.VarChar(64)
+  type      String   @db.VarChar(16)
+  createdAt DateTime @default(now())
+
+  comment Comment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+  @@unique([commentId, userId])
+  @@unique([commentId, ip])
+  @@index([commentId], map: "idx_commentreaction_commentid")
 }
 
 model ListConfig {

--- a/src/functions/comment.ts
+++ b/src/functions/comment.ts
@@ -1,0 +1,137 @@
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { introspect, jsonReply } from "..";
+import { Comment } from "../lib/Comment";
+import {
+  CommentCreateBodySchema,
+  CommentUpdateBodySchema,
+} from "../models/Comment";
+import { AccessError } from "../errors/AccessError";
+import { ValidationError } from "../errors/ValidationError";
+
+export async function comment(
+  request: HttpRequest,
+  context: InvocationContext
+): Promise<HttpResponseInit> {
+  const introspection = await introspect(request);
+  const userId = introspection.isLoggedIn ? introspection.user.id : null;
+
+  switch (request.method) {
+    case "GET": {
+      const entityId = parseInt(request.query.get("entityId") || "");
+      if (!entityId) {
+        return { status: 400 };
+      }
+
+      const result = await Comment.getForEntity(entityId, userId);
+      if (result.isErr()) {
+        context.error(result.error);
+        return { status: 500 };
+      }
+
+      return jsonReply({ comments: result.value });
+    }
+
+    case "POST": {
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return { status: 400 };
+      }
+
+      const parsed = CommentCreateBodySchema.safeParse(body);
+      if (!parsed.success) {
+        return { status: 400, body: JSON.stringify(parsed.error.issues) };
+      }
+
+      const result = await Comment.create(userId, parsed.data);
+      if (result.isErr()) {
+        context.error(result.error);
+        if (result.error instanceof ValidationError) {
+          return { status: 400 };
+        }
+        return { status: 500 };
+      }
+
+      return jsonReply(result.value);
+    }
+
+    case "PATCH": {
+      if (!introspection.isLoggedIn) {
+        return { status: 403 };
+      }
+      const id = parseInt(request.params.id || "");
+      if (!id) {
+        return { status: 400 };
+      }
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return { status: 400 };
+      }
+
+      const parsed = CommentUpdateBodySchema.safeParse(body);
+      if (!parsed.success) {
+        return { status: 400, body: JSON.stringify(parsed.error.issues) };
+      }
+
+      const result = await Comment.setPublished(
+        userId,
+        id,
+        parsed.data.published
+      );
+      if (result.isErr()) {
+        context.error(result.error);
+        if (result.error instanceof AccessError) {
+          return { status: 403 };
+        }
+        if (result.error instanceof ValidationError) {
+          return { status: 400 };
+        }
+        return { status: 500 };
+      }
+
+      return jsonReply(result.value);
+    }
+
+    case "DELETE": {
+      if (!introspection.isLoggedIn) {
+        return { status: 403 };
+      }
+      const id = parseInt(request.params.id || "");
+      if (!id) {
+        return { status: 400 };
+      }
+
+      const result = await Comment.delete(userId, id);
+      if (result.isErr()) {
+        context.error(result.error);
+        if (result.error instanceof AccessError) {
+          return { status: 403 };
+        }
+        if (result.error instanceof ValidationError) {
+          return { status: 400 };
+        }
+        return { status: 500 };
+      }
+
+      return { status: 204 };
+    }
+  }
+
+  return { status: 405 };
+}
+
+app.http("comment", {
+  methods: ["GET", "POST", "PATCH", "DELETE"],
+  authLevel: "anonymous",
+  handler: comment,
+  route: "comment/{id?}",
+});

--- a/src/functions/commentReaction.ts
+++ b/src/functions/commentReaction.ts
@@ -1,0 +1,73 @@
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { getIp, introspect, jsonReply } from "..";
+import { Comment } from "../lib/Comment";
+import { CommentReactionBodySchema } from "../models/Comment";
+import { ValidationError } from "../errors/ValidationError";
+
+export async function commentReaction(
+  request: HttpRequest,
+  context: InvocationContext
+): Promise<HttpResponseInit> {
+  const introspection = await introspect(request);
+  const userId = introspection.isLoggedIn ? introspection.user.id : null;
+  const ip = userId ? null : getIp(request);
+
+  const id = parseInt(request.params.id || "");
+  if (!id) {
+    return { status: 400 };
+  }
+
+  switch (request.method) {
+    case "POST": {
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return { status: 400 };
+      }
+
+      const parsed = CommentReactionBodySchema.safeParse(body);
+      if (!parsed.success) {
+        return { status: 400, body: JSON.stringify(parsed.error.issues) };
+      }
+
+      const result = await Comment.react(userId, ip, id, parsed.data.type);
+      if (result.isErr()) {
+        context.error(result.error);
+        if (result.error instanceof ValidationError) {
+          return { status: 400 };
+        }
+        return { status: 500 };
+      }
+
+      return jsonReply({ counts: result.value });
+    }
+
+    case "DELETE": {
+      const result = await Comment.removeReaction(userId, ip, id);
+      if (result.isErr()) {
+        context.error(result.error);
+        if (result.error instanceof ValidationError) {
+          return { status: 400 };
+        }
+        return { status: 500 };
+      }
+
+      return jsonReply({ counts: result.value });
+    }
+  }
+
+  return { status: 405 };
+}
+
+app.http("commentReaction", {
+  methods: ["POST", "DELETE"],
+  authLevel: "anonymous",
+  handler: commentReaction,
+  route: "commentReaction/{id}",
+});

--- a/src/functions/entityConfig.ts
+++ b/src/functions/entityConfig.ts
@@ -66,6 +66,7 @@ export async function listConfig(
         public: createBody.public,
         uniqueConstraints: [],
         allowTags: createBody.allowTags,
+        allowComments: createBody.allowComments,
       });
 
       if (entityConfigRes.isErr()) {

--- a/src/lib/Comment.ts
+++ b/src/lib/Comment.ts
@@ -1,0 +1,261 @@
+import { Result, err, ok } from "neverthrow";
+import { prisma } from "..";
+import {
+  CommentCounts,
+  CommentCreateBody,
+  CommentReactionType,
+  CommentSpec,
+} from "../models/Comment";
+import { ValidationError } from "../errors/ValidationError";
+import { AccessError } from "../errors/AccessError";
+
+interface CommentRecord {
+  id: number;
+  entityId: number;
+  userId: string | null;
+  guestName: string | null;
+  body: string;
+  published: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class Comment {
+  static async create(
+    userId: string | null,
+    data: CommentCreateBody
+  ): Promise<Result<CommentSpec, Error>> {
+    try {
+      const entity = await prisma.entity.findUnique({
+        where: { id: data.entityId },
+        select: { allowComments: true },
+      });
+
+      if (!entity) {
+        return err(new ValidationError("Entity not found"));
+      }
+      if (!entity.allowComments) {
+        return err(
+          new ValidationError("Comments are not allowed on this entity")
+        );
+      }
+      if (!userId && !data.guestName) {
+        return err(
+          new ValidationError("guestName is required for guest comments")
+        );
+      }
+
+      const comment = await prisma.comment.create({
+        data: {
+          entityId: data.entityId,
+          userId,
+          guestName: userId ? null : data.guestName,
+          body: data.body,
+        },
+      });
+
+      return ok(Comment.mapDataToSpec(comment));
+    } catch (error) {
+      return err(new Error("Failed to create comment", { cause: error }));
+    }
+  }
+
+  static async getForEntity(
+    entityId: number,
+    viewerUserId: string | null
+  ): Promise<Result<CommentSpec[], Error>> {
+    try {
+      const entity = await prisma.entity.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      if (!entity) {
+        return err(new ValidationError("Entity not found"));
+      }
+
+      const isOwner = viewerUserId !== null && entity.userId === viewerUserId;
+
+      const comments = await prisma.comment.findMany({
+        where: {
+          entityId,
+          ...(isOwner ? {} : { published: true }),
+        },
+        orderBy: { createdAt: "asc" },
+      });
+
+      const counts = await Comment.getCountsForComments(
+        comments.map((comment) => comment.id)
+      );
+
+      return ok(
+        comments.map((comment) =>
+          Comment.mapDataToSpec(comment, counts[comment.id])
+        )
+      );
+    } catch (error) {
+      return err(new Error("Failed to retrieve comments", { cause: error }));
+    }
+  }
+
+  static async setPublished(
+    userId: string,
+    commentId: number,
+    published: boolean
+  ): Promise<Result<CommentSpec, Error>> {
+    try {
+      const comment = await prisma.comment.findUnique({
+        where: { id: commentId },
+        include: { entity: { select: { userId: true } } },
+      });
+      if (!comment) {
+        return err(new ValidationError("Comment not found"));
+      }
+      if (comment.entity.userId !== userId) {
+        return err(
+          new AccessError("Not authorized to moderate this comment")
+        );
+      }
+
+      const updated = await prisma.comment.update({
+        where: { id: commentId },
+        data: { published },
+      });
+
+      const counts = await Comment.getCountsForComments([commentId]);
+      return ok(Comment.mapDataToSpec(updated, counts[commentId]));
+    } catch (error) {
+      return err(new Error("Failed to update comment", { cause: error }));
+    }
+  }
+
+  static async delete(
+    userId: string,
+    commentId: number
+  ): Promise<Result<boolean, Error>> {
+    try {
+      const comment = await prisma.comment.findUnique({
+        where: { id: commentId },
+        include: { entity: { select: { userId: true } } },
+      });
+      if (!comment) {
+        return err(new ValidationError("Comment not found"));
+      }
+      if (comment.userId !== userId && comment.entity.userId !== userId) {
+        return err(new AccessError("Not authorized to delete this comment"));
+      }
+
+      await prisma.comment.delete({ where: { id: commentId } });
+      return ok(true);
+    } catch (error) {
+      return err(new Error("Failed to delete comment", { cause: error }));
+    }
+  }
+
+  static async react(
+    userId: string | null,
+    ip: string | null,
+    commentId: number,
+    type: CommentReactionType
+  ): Promise<Result<CommentCounts, Error>> {
+    try {
+      const comment = await prisma.comment.findUnique({
+        where: { id: commentId },
+        select: { id: true },
+      });
+      if (!comment) {
+        return err(new ValidationError("Comment not found"));
+      }
+
+      if (userId) {
+        await prisma.commentReaction.upsert({
+          where: { commentId_userId: { commentId, userId } },
+          update: { type },
+          create: { commentId, userId, type },
+        });
+      } else {
+        await prisma.commentReaction.upsert({
+          where: { commentId_ip: { commentId, ip } },
+          update: { type },
+          create: { commentId, ip, type },
+        });
+      }
+
+      const counts = await Comment.getCountsForComments([commentId]);
+      return ok(counts[commentId] ?? { like: 0, dislike: 0 });
+    } catch (error) {
+      return err(new Error("Failed to react to comment", { cause: error }));
+    }
+  }
+
+  static async removeReaction(
+    userId: string | null,
+    ip: string | null,
+    commentId: number
+  ): Promise<Result<CommentCounts, Error>> {
+    try {
+      if (userId) {
+        await prisma.commentReaction.deleteMany({
+          where: { commentId, userId },
+        });
+      } else {
+        await prisma.commentReaction.deleteMany({
+          where: { commentId, ip },
+        });
+      }
+
+      const counts = await Comment.getCountsForComments([commentId]);
+      return ok(counts[commentId] ?? { like: 0, dislike: 0 });
+    } catch (error) {
+      return err(new Error("Failed to remove reaction", { cause: error }));
+    }
+  }
+
+  static async getCountsForComments(
+    commentIds: number[]
+  ): Promise<Record<number, CommentCounts>> {
+    const counts: Record<number, CommentCounts> = {};
+    for (const id of commentIds) {
+      counts[id] = { like: 0, dislike: 0 };
+    }
+
+    if (commentIds.length === 0) {
+      return counts;
+    }
+
+    const grouped = await prisma.commentReaction.groupBy({
+      by: ["commentId", "type"],
+      where: { commentId: { in: commentIds } },
+      _count: { _all: true },
+    });
+
+    for (const row of grouped) {
+      // CommentReaction.type is a plain VARCHAR column holding the string value of
+      // api-spec's CommentReactionType — compared by value here, not by enum identifier,
+      // since that's all a string column can hold.
+      if (row.type === "like") {
+        counts[row.commentId].like = row._count._all;
+      } else if (row.type === "dislike") {
+        counts[row.commentId].dislike = row._count._all;
+      }
+    }
+
+    return counts;
+  }
+
+  static mapDataToSpec(
+    data: CommentRecord,
+    counts: CommentCounts = { like: 0, dislike: 0 }
+  ): CommentSpec {
+    return {
+      id: data.id,
+      entityId: data.entityId,
+      userId: data.userId,
+      guestName: data.guestName,
+      body: data.body,
+      published: data.published,
+      createdAt: data.createdAt.toISOString(),
+      updatedAt: data.updatedAt.toISOString(),
+      counts,
+    };
+  }
+}

--- a/src/lib/Entity.ts
+++ b/src/lib/Entity.ts
@@ -153,6 +153,15 @@ export class Entity {
 
       await Hook.trigger({ type: HookType.PRE_CREATE, userId, data });
 
+      let allowComments = data.allowComments ?? false;
+      if (data.allowComments === undefined && data.entityConfigId !== undefined) {
+        const entityConfig = await prisma.entityConfig.findUnique({
+          where: { id: data.entityConfigId },
+          select: { allowComments: true },
+        });
+        allowComments = entityConfig?.allowComments ?? false;
+      }
+
       const entity = await prisma.entity.create({
         data: {
           userId: data.userId ?? userId,
@@ -160,6 +169,7 @@ export class Entity {
           published: data.published ?? false,
           suggested: data.suggested ?? false,
           identified: data.identified ?? false,
+          allowComments,
           ...(data.createdAt
             ? {
                 createdAt: Util.getDateInTimeZone(
@@ -291,7 +301,8 @@ export class Entity {
       if (
         data.published !== undefined ||
         data.suggested !== undefined ||
-        data.identified !== undefined
+        data.identified !== undefined ||
+        data.allowComments !== undefined
       ) {
         await prisma.entity.update({
           where: { id, userId },
@@ -302,6 +313,9 @@ export class Entity {
             }),
             ...(data.identified !== undefined && {
               identified: data.identified,
+            }),
+            ...(data.allowComments !== undefined && {
+              allowComments: data.allowComments,
             }),
           },
         });

--- a/src/lib/EntityConfig.ts
+++ b/src/lib/EntityConfig.ts
@@ -117,6 +117,7 @@ export class EntityConfig {
             ? { revision: { connect: { id: entityConfig.revisionOf } } }
             : {}),
           allowTags: entityConfig.allowTags ?? false,
+          allowComments: entityConfig.allowComments ?? false,
         },
         include: entityConfigInclude,
       });
@@ -168,6 +169,7 @@ export class EntityConfig {
           aiIdentifyPrompt: entityConfig.aiIdentifyPrompt,
           public: entityConfig.public,
           allowTags: entityConfig.allowTags,
+          allowComments: entityConfig.allowComments,
         },
         where: { id: entityConfig.id },
         include: entityConfigInclude,
@@ -348,6 +350,7 @@ export class EntityConfig {
         propertyIds: uc.properties.map((p) => p.propertyConfigId),
       })),
       allowTags: data.allowTags,
+      allowComments: data.allowComments,
     };
   }
 

--- a/src/lib/EntityMapper.ts
+++ b/src/lib/EntityMapper.ts
@@ -240,6 +240,7 @@ export class EntityMapper {
       suggested: entity.suggested,
       published: entity.published,
       identified: entity.identified,
+      allowComments: entity.allowComments,
     };
   }
 }

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { CommentReactionType } from "api-spec/models/Comment";
+
+export { CommentReactionType };
+
+export const commentInclude = {
+  reactions: true,
+} satisfies Prisma.CommentFindUniqueArgs["include"];
+
+const prismaComment = Prisma.validator<Prisma.CommentFindUniqueArgs>()({
+  where: { id: 0 },
+  include: commentInclude,
+});
+
+export type PrismaComment = Prisma.CommentGetPayload<typeof prismaComment>;
+
+export interface CommentCounts {
+  like: number;
+  dislike: number;
+}
+
+export interface CommentSpec {
+  id: number;
+  entityId: number;
+  userId: string | null;
+  guestName: string | null;
+  body: string;
+  published: boolean;
+  createdAt: string;
+  updatedAt: string;
+  counts: CommentCounts;
+}
+
+export const CommentCreateBodySchema = z.object({
+  entityId: z.number(),
+  body: z.string().min(1).max(4000),
+  guestName: z.string().min(1).max(128).optional(),
+});
+export type CommentCreateBody = z.infer<typeof CommentCreateBodySchema>;
+
+export const CommentUpdateBodySchema = z.object({
+  published: z.boolean(),
+});
+export type CommentUpdateBody = z.infer<typeof CommentUpdateBodySchema>;
+
+export const CommentReactionBodySchema = z.object({
+  type: z.nativeEnum(CommentReactionType),
+});
+export type CommentReactionBody = z.infer<typeof CommentReactionBodySchema>;

--- a/src/models/Entity.ts
+++ b/src/models/Entity.ts
@@ -20,6 +20,7 @@ export interface EntityBodyPayload {
   suggested?: boolean;
   identified?: boolean;
   createdAt?: string;
+  allowComments?: boolean;
 }
 
 export type ContextEntities = Record<number, PrismaEntity[]>;

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -13,6 +13,7 @@ import { AccessPolicyAssignmentSchema, AccessPolicyBodySchema, AccessPolicyGroup
 import { ListConfigCreateBodySchema } from "../models/ListConfig";
 import { TagCreateBodySchema } from "../models/Tag";
 import { LeaderboardCreateBodySchema, LeaderboardRecordSchema } from "../models/Leaderboard";
+import { CommentCreateBodySchema, CommentUpdateBodySchema, CommentReactionBodySchema } from "../models/Comment";
 
 export const registry = new OpenAPIRegistry();
 
@@ -45,6 +46,7 @@ const EntityConfigSchema = z.object({
   aiIdentifyPrompt: z.string(),
   public: z.boolean(),
   allowTags: z.boolean(),
+  allowComments: z.boolean(),
   uniqueConstraints: z.array(z.object({ propertyIds: z.array(z.number()) })),
 });
 
@@ -58,6 +60,7 @@ const EntitySchema = z.object({
   properties: z.array(EntityPropertySchema),
   suggested: z.boolean(),
   identified: z.boolean(),
+  allowComments: z.boolean(),
 });
 
 const AccessPolicySchema = z.object({
@@ -148,6 +151,7 @@ const EntityBodyPayloadSchema = z.object({
   suggested: z.boolean().optional(),
   identified: z.boolean().optional(),
   createdAt: z.string().optional(),
+  allowComments: z.boolean().optional(),
 });
 
 const EntityConfigCreateBodySchema = z.object({
@@ -161,6 +165,7 @@ const EntityConfigCreateBodySchema = z.object({
   aiIdentifyPrompt: z.string().optional(),
   public: z.boolean().optional(),
   allowTags: z.boolean().optional(),
+  allowComments: z.boolean().optional(),
   uniqueConstraints: z.array(z.object({ propertyIds: z.array(z.number()) })).optional(),
 });
 
@@ -183,6 +188,23 @@ const ExportBodySchema = z.object({
   entityConfigIds: z.array(z.number()),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
+});
+
+const CommentCountsSchema = z.object({
+  like: z.number(),
+  dislike: z.number(),
+});
+
+const CommentSchema = z.object({
+  id: z.number(),
+  entityId: z.number(),
+  userId: z.string().nullable(),
+  guestName: z.string().nullable(),
+  body: z.string(),
+  published: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  counts: CommentCountsSchema,
 });
 
 // ─── Register named schemas ───────────────────────────────────────────────────
@@ -210,6 +232,9 @@ const AccessPolicyAssignment = registry.register("AccessPolicyAssignment", Acces
 const ListConfigCreateBody = registry.register("ListConfigCreateBody", ListConfigCreateBodySchema);
 const TagCreateBody = registry.register("TagCreateBody", TagCreateBodySchema);
 const LeaderboardCreateBody = registry.register("LeaderboardCreateBody", LeaderboardCreateBodySchema);
+const CommentCreateBody = registry.register("CommentCreateBody", CommentCreateBodySchema);
+const CommentUpdateBody = registry.register("CommentUpdateBody", CommentUpdateBodySchema);
+const CommentReactionBody = registry.register("CommentReactionBody", CommentReactionBodySchema);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1584,6 +1609,96 @@ registry.registerPath({
       description: "Leaderboard with new rank",
       ...json(z.object({ rank: z.number(), records: z.array(LeaderboardRecordSchema) })),
     },
+  },
+});
+
+// ─── Comments ─────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  tags: ["Comments"],
+  method: "get",
+  path: "/comment",
+  summary: "List comments for an entity (owners see unpublished comments too)",
+  request: { query: z.object({ entityId: z.string() }) },
+  responses: {
+    200: { description: "Comments", ...json(z.object({ comments: z.array(CommentSchema) })) },
+    400: badRequest,
+    500: serverError,
+  },
+});
+
+registry.registerPath({
+  tags: ["Comments"],
+  method: "post",
+  path: "/comment",
+  summary: "Post a comment as an authenticated user or guest",
+  request: { body: { content: { "application/json": { schema: CommentCreateBody } } } },
+  responses: {
+    200: { description: "Created comment", ...json(CommentSchema) },
+    400: badRequest,
+    500: serverError,
+  },
+});
+
+registry.registerPath({
+  tags: ["Comments"],
+  method: "patch",
+  path: "/comment/{id}",
+  summary: "Publish or unpublish a comment (entity owner only)",
+  ...auth,
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { "application/json": { schema: CommentUpdateBody } } },
+  },
+  responses: {
+    200: { description: "Updated comment", ...json(CommentSchema) },
+    400: badRequest,
+    403: forbidden,
+    500: serverError,
+  },
+});
+
+registry.registerPath({
+  tags: ["Comments"],
+  method: "delete",
+  path: "/comment/{id}",
+  summary: "Delete a comment (entity owner or comment author)",
+  ...auth,
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    204: noContent,
+    400: badRequest,
+    403: forbidden,
+    500: serverError,
+  },
+});
+
+registry.registerPath({
+  tags: ["Comments"],
+  method: "post",
+  path: "/commentReaction/{id}",
+  summary: "Like or dislike a comment (authenticated users or guests, deduped by user/IP)",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { "application/json": { schema: CommentReactionBody } } },
+  },
+  responses: {
+    200: { description: "Updated reaction counts", ...json(z.object({ counts: CommentCountsSchema })) },
+    400: badRequest,
+    500: serverError,
+  },
+});
+
+registry.registerPath({
+  tags: ["Comments"],
+  method: "delete",
+  path: "/commentReaction/{id}",
+  summary: "Remove your reaction from a comment",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: "Updated reaction counts", ...json(z.object({ counts: CommentCountsSchema })) },
+    400: badRequest,
+    500: serverError,
   },
 });
 


### PR DESCRIPTION
## Summary
- Adds Comment/CommentReaction models: comments postable by authenticated users or guests, with like/dislike reactions deduped by userId (logged-in) or IP (guest)
- Adds a published moderation flag on comments, defaulting to unpublished; entity owners see unpublished comments, everyone else sees only published ones
- Adds an allowComments toggle on both Entity and EntityConfig (new entities inherit the config default when not explicitly set)
- Bumps api-spec to 1.123.0 and uses its named CommentReactionType enum for request validation, instead of introducing a second, order-dependent local enum
- CommentReaction.type is persisted as a plain VARCHAR string (matching this repos existing convention for api-spec-sourced enums, e.g. analysisType), so reordering enum members in api-spec can never desync stored data
- New endpoints: GET/POST /comment, PATCH/DELETE /comment/:id, POST/DELETE /commentReaction/:id, all registered in src/openapi/registry.ts

## Caveats (sandbox had no network access or installed node_modules)
- Could not run npm install, npm run build, prisma generate, or prisma migrate dev. The migration SQL in prisma/migrations/20260623090000_add_comments/ was hand-written to mirror what Prisma would generate, but is unverified against a live database
- Could not run npm run spec. openapi.json was NOT regenerated; please run it and commit the result before merging
- package-lock.json was not updated to reflect the api-spec#1.123.0 bump
- The api-spec/models/Comment import path and exact shape/casing of CommentReactionType are based on this repos existing import conventions but unverified against the actual published package

Generated with Claude Code (https://claude.ai/code)