### PR TITLE
feat: support orderProperties bulk operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@azure/storage-blob": "^12.28.0",
         "@azure/storage-queue": "^12.29.0",
         "@prisma/client": "^6.17.1",
-        "api-spec": "github:SikoSoft/api-spec#1.123.1",
+        "api-spec": "github:SikoSoft/api-spec#1.124.0",
         "argon2": "^0.41.1",
         "googleapis": "^171.4.0",
         "into-stream": "^9.0.0",
@@ -233,9 +233,9 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.32.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.32.0.tgz",
-      "integrity": "sha512-80LzSNnFQye2LCCBFghAJS6jJQJ7N4bfgZ6qDMgVGRtugZ7TLDKQZ2hczMigmZH3jAcMRdma/IygsC5+0gT7Tw==",
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+      "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -249,12 +249,12 @@
         "@azure/core-util": "^1.11.0",
         "@azure/core-xml": "^1.4.5",
         "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.4.0",
+        "@azure/storage-common": "^12.4.1",
         "events": "^3.0.0",
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/storage-common": {
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@azure/storage-queue": {
-      "version": "12.30.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-queue/-/storage-queue-12.30.0.tgz",
-      "integrity": "sha512-204lc/W0nnZy0/JXGXAVsQG9LmRWGVrh28uxkWd6lV5/G/vHlFZOLxiTS5DUdLcnZ+OHhsClRJnMWgHX2X0vdA==",
+      "version": "12.31.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-queue/-/storage-queue-12.31.0.tgz",
+      "integrity": "sha512-OzhvKO7G8+EXkUQPbKFkO7JNIAMkQZ9gMyZ85dsTCOk8jRRCbGbn3wsk3qrCAf6XWm+E2/fUsdLbX4YCOAWEKw==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -293,11 +293,11 @@
         "@azure/core-util": "^1.11.0",
         "@azure/core-xml": "^1.4.3",
         "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.4.0",
+        "@azure/storage-common": "^12.4.1",
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2055,8 +2055,8 @@
       "license": "MIT"
     },
     "node_modules/api-spec": {
-      "version": "1.123.1",
-      "resolved": "git+ssh://git@github.com/SikoSoft/api-spec.git#9e620ae34d8fdd18911763c9b3ce742df19c2660",
+      "version": "1.124.0",
+      "resolved": "git+ssh://git@github.com/SikoSoft/api-spec.git#421842477e5db095b4b909a8569e865eb9c7be49",
       "license": "ISC"
     },
     "node_modules/arg": {
@@ -2209,15 +2209,15 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
+      "integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2885,13 +2885,14 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
-      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
         "is-date-object": "^1.1.0",
@@ -2961,9 +2962,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3191,9 +3192,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3710,9 +3711,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
-      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -4840,9 +4841,9 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -5058,9 +5059,9 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
-      "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5427,9 +5428,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -5564,12 +5565,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5920,9 +5922,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@azure/storage-blob": "^12.28.0",
     "@azure/storage-queue": "^12.29.0",
     "@prisma/client": "^6.17.1",
-    "api-spec": "github:SikoSoft/api-spec#1.123.1",
+    "api-spec": "github:SikoSoft/api-spec#1.124.0",
     "argon2": "^0.41.1",
     "googleapis": "^171.4.0",
     "into-stream": "^9.0.0",

--- a/src/functions/operation.ts
+++ b/src/functions/operation.ts
@@ -146,6 +146,18 @@ export async function operation(
         }
       }
       break;
+    case OperationType.ORDER_PROPERTIES:
+      for (const entityId of body.entities) {
+        const orderPropertiesRes = await EntityProperty.orderProperties(
+          entityId,
+          body.operation.properties
+        );
+        if (orderPropertiesRes.isErr()) {
+          context.error(orderPropertiesRes.error);
+          return { status: 500 };
+        }
+      }
+      break;
   }
 
   return jsonReply({ status: 1 });

--- a/src/lib/EntityProperty.ts
+++ b/src/lib/EntityProperty.ts
@@ -1296,6 +1296,86 @@ export class EntityProperty {
     }
   }
 
+  static async orderProperties(
+    entityId: number,
+    properties: ApiEntityProperty[]
+  ): Promise<Result<null, Error>> {
+    try {
+      const calculatedIds = await EntityProperty.getCalculatedConfigIds(
+        properties.map((p) => p.propertyConfigId)
+      );
+
+      const regularProperties = properties.filter(
+        (p) => !calculatedIds.has(p.propertyConfigId) && p.id
+      );
+      const calculatedProperties = properties.filter((p) =>
+        calculatedIds.has(p.propertyConfigId)
+      );
+
+      const dataTypesRes =
+        await EntityProperty.getDataTypesForProperties(regularProperties);
+      if (dataTypesRes.isErr()) {
+        return err(dataTypesRes.error);
+      }
+      const dataTypes = dataTypesRes.value;
+
+      for (const property of regularProperties) {
+        const where = { entityId, propertyValueId: property.id };
+        switch (dataTypes[property.propertyConfigId]) {
+          case DataType.BOOLEAN:
+            await prisma.entityBooleanProperty.updateMany({
+              where,
+              data: { order: property.order },
+            });
+            break;
+          case DataType.DATE:
+            await prisma.entityDateProperty.updateMany({
+              where,
+              data: { order: property.order },
+            });
+            break;
+          case DataType.IMAGE:
+            await prisma.entityImageProperty.updateMany({
+              where,
+              data: { order: property.order },
+            });
+            break;
+          case DataType.INT:
+            await prisma.entityIntProperty.updateMany({
+              where,
+              data: { order: property.order },
+            });
+            break;
+          case DataType.SHORT_TEXT:
+            await prisma.entityShortTextProperty.updateMany({
+              where,
+              data: { order: property.order },
+            });
+            break;
+          case DataType.LONG_TEXT:
+            await prisma.entityLongTextProperty.updateMany({
+              where,
+              data: { order: property.order },
+            });
+            break;
+        }
+      }
+
+      for (const property of calculatedProperties) {
+        await prisma.entityCalculatedProperty.updateMany({
+          where: { entityId, propertyConfigId: property.propertyConfigId },
+          data: { order: property.order },
+        });
+      }
+
+      return ok(null);
+    } catch (error) {
+      return err(
+        new Error("Failed to order entity properties", { cause: error })
+      );
+    }
+  }
+
   static async getTextValues(
     entityId: number
   ): Promise<Result<string[], Error>> {


### PR DESCRIPTION
## Summary
- Bump `api-spec` to 1.124.0
- Add support for the `orderProperties` bulk operation type on `/operation`
- Update only the order of entity properties included in the payload, ignoring others

## Note
`npm install` could not be run in the automated environment — please run it locally to update `package-lock.json` and confirm the new `api-spec` types match before merging.

Closes #64

Generated with [Claude Code](https://claude.ai/code)