### PR TITLE
fix: don't reset streak current to 0 when today's segment computes to 0

### DIFF
--- a/docs/medal-system.md
+++ b/docs/medal-system.md
@@ -82,7 +82,7 @@ A `StreakRequest` measures **consecutive time periods** where a condition held. 
 
 1. Generate `length` lookback segments from now. Segment 0 is the current period; segment `length - 1` is the oldest.
 2. For each segment, resolve the inner fact value.
-3. If the value is missing for a segment, **the streak is broken at that point** — a gap in data is treated as failure.
+3. If the value is missing for a segment, **the streak is broken at that point** — a gap in data is treated as failure. **Exception: segment 0** (the current, still-in-progress period). Since the period hasn't ended yet, an unresolved value *or* a resolved value that doesn't yet satisfy `innerOperator`/`innerValue` (e.g. an `entityCount` of 0 because nothing has been logged today) is skipped rather than treated as a break, so `current` reflects the run through the most recently *completed* period instead of dropping to 0 every time the current period hasn't been satisfied yet.
 4. Compare the value against `innerOperator`/`innerValue`. If the condition fails, stop.
 5. Otherwise increment the counter and continue to the next (older) segment.
 6. The final count is stored in the fact map under the alias.

--- a/src/lib/Streak.ts
+++ b/src/lib/Streak.ts
@@ -318,10 +318,11 @@ export class Streak {
       }
     } else {
       // Segment 0 is the current (possibly in-progress) period. Fact data for the current
-      // period may return undefined or zero simply because the period hasn't ended yet, not
-      // because the user failed the condition. Skipping a missing segment-0 value preserves
-      // the current streak through the most recently completed period rather than always
-      // resetting it to 0 mid-period.
+      // period may resolve to undefined or to a real value that doesn't yet satisfy the
+      // condition (e.g. entityCount of 0 because nothing has been logged today), simply
+      // because the period hasn't ended yet — not because the user failed the condition.
+      // Skipping segment 0 in either case preserves the current streak through the most
+      // recently completed period rather than always resetting it to 0 mid-period.
       for (let i = 0; i < segments.length; i++) {
         const segment = segments[i];
         const injected = Streak.injectDateRange(
@@ -344,9 +345,15 @@ export class Streak {
         );
 
         const value = await Fact.resolve(injected, userId, { bypassCache });
-        if (i === 0 && value === undefined) {
+        const currentPeriodIncomplete =
+          i === 0 &&
+          (value === undefined ||
+            !Streak.evalInner(value, ctx.innerOperator, ctx.innerValue));
+        if (currentPeriodIncomplete) {
           Logger.log(
-            `[Streak] resolveContext segment=${segment.key} (current period) returned undefined — skipping without breaking streak`
+            `[Streak] resolveContext segment=${segment.key} (current period) value=${JSON.stringify(
+              value
+            )} does not yet satisfy condition — skipping without breaking streak`
           );
           continue;
         }


### PR DESCRIPTION
## Summary
- Fixes #70: fetching a streak before anything has been logged today incorrectly reset `current` to 0, because the segment-0 "still in progress" guard in `Streak.resolveContext` only handled `undefined` values, not a real computed `0` (which is what fact-cache-backed ops like `entityCount` return when there's no data yet).
- Segment 0 is now skipped (without breaking the streak) whenever its value is undefined or simply doesn't yet satisfy the inner condition, matching the behavior already described in the surrounding comments.
- Updated `docs/medal-system.md` to describe the segment-0 exception.

## Test plan
- [ ] `npm run build` / typecheck (not run in this sandbox - no network access to install dependencies)
- [ ] Manually verify: create a streak-eligible entity yesterday, none today, confirm `GET /streakRequest` still reports a current streak instead of 0

Generated with [Claude Code](https://claude.ai/code)